### PR TITLE
Revive MockQuestion type

### DIFF
--- a/src/types/Topic.types.ts
+++ b/src/types/Topic.types.ts
@@ -1,13 +1,18 @@
 import type {Section} from "./Section.types";
 import type {SubjectKey} from "../data/subjects";
-// import type {MockQuestion} from "../components/MockInterview/types";
+
+export type MockQuestion = {
+  id: string;
+  question: string;
+  answer: string;
+};
 
 export type Topic = {
   name: string;
   summary: string;
   code?: string;
   interview?: boolean;
-  // mockQuestions?: MockQuestion[];
+  mockQuestions?: MockQuestion[];
 };
 
 export type CheckedTopics = Record<string, boolean>;


### PR DESCRIPTION
Restores the `MockQuestion` type that was previously commented out, defining it inline in `Topic.types.ts` and re-enabling the `mockQuestions` field on the `Topic` type.

## Changes
- Added `MockQuestion` type with `id`, `question`, and `answer` fields to `src/types/Topic.types.ts`
- Restored the `mockQuestions?: MockQuestion[]` field on the `Topic` type

Co-Authored-By: Oz <oz-agent@warp.dev>