### PR TITLE
Mobile fixes: responsive layout and mobile nav

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {Toolbar} from "./components/Toolbar";
 import SectionCard from "./components/SectionCard";
 import {TopicModal} from "./components/TopicModal";
 import {MockInterview} from "./components/MockInterview";
+import {SubjectNav} from "./components/SubjectNav";
 
 import {getTopicKey} from "./utils/topicKeys";
 import {filterSections} from "./utils/filterSections";
@@ -27,8 +28,6 @@ export default function App() {
 
   const sections = subjectData[subject].sections;
   const subjects = Object.entries(subjectData);
-
-  console.log(sections);
 
   const {
     checkedTopics,
@@ -72,7 +71,16 @@ export default function App() {
     return () => window.removeEventListener("keydown", handler);
   }, []);
 
+  useEffect(() => {
+    if (showMockQuestions) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  }, [showMockQuestions]);
+
   const handleCloseModal = () => {
+    document.body.style.overflow = "";
     setSelectedSection(null);
     setExpandedTopic(null);
   };
@@ -92,22 +100,12 @@ export default function App() {
   ).length;
 
   return (
-    <div className="min-h-screen bg-bg p-10 text-text">
-      <div className="fixed top-0 left-0 w-full mb-6 p-1 flex flex-wrap gap-1 bg-black/20 justify-center">
-        {subjects.map(([key, value]) => (
-          <button
-            key={key}
-            onClick={() => setSubject(key as SubjectKey)}
-            className={`rounded px-4 py-2 text-xs font-medium transition ${
-              subject === key
-                ? " text-amber-400 hover:text-amber-600"
-                : " text-white hover:text-amber-600"
-            }`}
-          >
-            {value.label}
-          </button>
-        ))}
-      </div>
+    <div className="min-h-screen bg-bg p-10 pt-0 text-text">
+      <SubjectNav
+        subjects={subjects}
+        subject={subject}
+        setSubject={setSubject}
+      />
       <div className="mx-auto max-w-7xl">
         <header className="mt-4 mb-8">
           <h1 className="mb-0 text-3xl font-bold">

--- a/src/components/MockInterview/MockInterviewNoQuestions.tsx
+++ b/src/components/MockInterview/MockInterviewNoQuestions.tsx
@@ -15,7 +15,7 @@ export function MockInterviewNoQuestions({
         className="w-full max-w-2xl rounded-2xl bg-slate-800 p-6"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-4 flex items-center justify-between">
+        <div className="mb-4 flex flex-col lg:flex-row items-center justify-between">
           <h2 className="text-xl font-semibold">
             {subjectData[subject].label} Mock Interview
           </h2>

--- a/src/components/MockInterview/MockInterviewQuestions.tsx
+++ b/src/components/MockInterview/MockInterviewQuestions.tsx
@@ -20,101 +20,105 @@ export function MockInterviewQuestions({
       onClick={onHandlePause}
     >
       <div
-        className="w-full max-w-3xl rounded-2xl bg-surface-light p-6"
+        className="w-full max-w-3xl max-h-full overflow-y-auto rounded-2xl bg-surface-light p-6"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="mb-4 flex flex-col">
-          <div className="flex justify-between items-center">
-            <h2 className="text-xl font-semibold">
-              {subjectData[subject].label} Mock Interview
-            </h2>
-            <Button
-              buttonLabel="Pause Interview"
-              buttonIcon="pause_circle"
-              buttonStyle="primary"
-              handleClick={onHandlePause}
-            />
-          </div>
-          <p className="mt-1 text-sm text-slate-400 text-left">
-            Question {currentIndex + 1} of {totalQuestions}
-          </p>
-        </div>
-
-        <div className="mb-4 flex flex-wrap items-center gap-2">
-          <span className="rounded bg-primary-500 px-2 py-0.5 text-xs font-medium text-black">
-            {currentQuestion.sectionTitle}
-          </span>
-          <span className="text-sm text-primary">
-            {currentQuestion.topicName}
-          </span>
-        </div>
-
-        <div className="mb-6 rounded-xl border border-black/10 bg-surface p-4">
-          <p className="text-base text-white">{currentQuestion.question}</p>
-        </div>
-
-        <div className="mb-4">
-          <label className="mb-2 block text-sm text-slate-300">
-            Your answer
-          </label>
-          <textarea
-            value={currentAnswer}
-            onChange={(e) => setCurrentAnswer(e.target.value)}
-            rows={8}
-            disabled={revealed}
-            className="w-full rounded-xl bg-surface px-4 py-3 text-xs text-white outline-none placeholder:text-slate-400 shadow-inner transition focus:bg-black/50 inset-shadow-sm inset-shadow-black/20"
-            placeholder="Type your answer here..."
-          />
-        </div>
-
-        {!revealed ? (
-          <div className="flex justify-end">
-            <Button
-              buttonLabel="Reveal Answer"
-              buttonStyle="primary"
-              handleClick={onHandleReveal}
-            />
-          </div>
-        ) : (
-          <div className="space-y-4">
-            <div className="rounded-xl border border-black/10 bg-surface p-4">
-              <h3 className="mb-2 text-sm font-medium text-primary">
-                Suggested answer
-              </h3>
-              <p className="text-sm text-slate-200">{currentQuestion.answer}</p>
+        <div>
+          <div className="mb-4 flex flex-col gap-4 lg:gap-0 items-center lg:items-start">
+            <div className="flex flex-col justify-between items-center">
+              <h2 className="text-xl font-semibold">
+                {subjectData[subject].label} Mock Interview
+              </h2>
+              <Button
+                buttonLabel="Pause Interview"
+                buttonIcon="pause_circle"
+                buttonStyle="primary"
+                handleClick={onHandlePause}
+              />
             </div>
+            <p className="mt-1 text-xs lg:text-sm text-slate-400 text-left">
+              Question {currentIndex + 1} of {totalQuestions}
+            </p>
+          </div>
 
-            <div>
-              <p className="mb-4 text-sm text-slate-300">Score your answer</p>
-              <div className="flex flex-wrap justify-center gap-2">
-                <button
-                  onClick={() => onHandleScore(0)}
-                  className="rounded-xl bg-danger px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-danger-dark"
-                >
-                  0 - Missed
-                </button>
-                <button
-                  onClick={() => onHandleScore(1)}
-                  className="rounded-xl bg-warning px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-warning-dark"
-                >
-                  1 - Weak
-                </button>
-                <button
-                  onClick={() => onHandleScore(2)}
-                  className="rounded-xl bg-info px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-info-dark"
-                >
-                  2 - Decent
-                </button>
-                <button
-                  onClick={() => onHandleScore(3)}
-                  className="rounded-xl bg-success px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-success-dark"
-                >
-                  3 - Strong
-                </button>
+          <div className="mb-4 flex flex-col lg:flex-row flex-wrap items-center lg:gap-2">
+            <span className="rounded bg-primary-500 px-2 py-0.5 text-xs font-medium text-black">
+              {currentQuestion.sectionTitle}
+            </span>
+            <span className="text-xxs lg:text-sm text-white">
+              {currentQuestion.topicName}
+            </span>
+          </div>
+
+          <div className="mb-6 rounded-xl border border-black/10 bg-surface p-4">
+            <p className="text-base text-white">{currentQuestion.question}</p>
+          </div>
+
+          <div className="mb-4">
+            <label className="mb-2 block text-sm text-slate-300">
+              Your answer
+            </label>
+            <textarea
+              value={currentAnswer}
+              onChange={(e) => setCurrentAnswer(e.target.value)}
+              rows={4}
+              disabled={revealed}
+              className="w-full rounded-xl bg-surface px-4 py-3 text-xs text-white outline-none placeholder:text-slate-400 shadow-inner transition focus:bg-black/50 inset-shadow-sm inset-shadow-black/20"
+              placeholder="Type your answer here..."
+            />
+          </div>
+
+          {!revealed ? (
+            <div className="flex justify-center lg:justify-end">
+              <Button
+                buttonLabel="Reveal Answer"
+                buttonStyle="primary"
+                handleClick={onHandleReveal}
+              />
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="rounded-xl border border-black/10 bg-surface p-4">
+                <h3 className="mb-2 text-sm font-medium text-primary">
+                  Suggested answer
+                </h3>
+                <p className="text-xs lg:text-base text-slate-200">
+                  {currentQuestion.answer}
+                </p>
+              </div>
+
+              <div>
+                <p className="mb-4 text-sm text-slate-300">Score your answer</p>
+                <div className="flex flex-wrap justify-center gap-2">
+                  <button
+                    onClick={() => onHandleScore(0)}
+                    className="rounded-xl bg-danger px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-danger-dark"
+                  >
+                    0 - Missed
+                  </button>
+                  <button
+                    onClick={() => onHandleScore(1)}
+                    className="rounded-xl bg-warning px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-warning-dark"
+                  >
+                    1 - Weak
+                  </button>
+                  <button
+                    onClick={() => onHandleScore(2)}
+                    className="rounded-xl bg-info px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-info-dark"
+                  >
+                    2 - Decent
+                  </button>
+                  <button
+                    onClick={() => onHandleScore(3)}
+                    className="rounded-xl bg-success px-4 py-1 text-xs text-white shadow-lg shadow-white/10 transition hover:bg-success-dark"
+                  >
+                    3 - Strong
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/SubjectNav.tsx
+++ b/src/components/SubjectNav.tsx
@@ -1,0 +1,98 @@
+import {useState, useEffect} from "react";
+import type {SubjectKey} from "../data/subjects";
+
+type SubjectNavProps = {
+  subjects: [string, {label: string}][];
+  subject: SubjectKey;
+  setSubject: (subject: SubjectKey) => void;
+};
+
+export function SubjectNav({subjects, subject, setSubject}: SubjectNavProps) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (mobileMenuOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  }, [mobileMenuOpen]);
+
+  const handleSelect = (key: SubjectKey) => {
+    setSubject(key);
+    setMobileMenuOpen(false);
+  };
+
+  return (
+    <>
+      {/* Mobile button */}
+      <div className="mb-4 flex justify-center lg:hidden">
+        <button
+          onClick={() => setMobileMenuOpen(true)}
+          className="flex items-center rounded-b bg-primary-500 px-4 py-2 text-xs font-medium text-black shadow-lg shadow-white/10 transition hover:bg-primary-600"
+        >
+          <span className="material-symbols-outlined mr-2">menu</span>
+          Subjects
+        </button>
+      </div>
+
+      {/* Desktop nav */}
+      <div className="mb-6 hidden w-full flex-wrap justify-center gap-1 bg-black/20 p-1 lg:fixed lg:left-0 lg:top-0 lg:flex">
+        {subjects.map(([key, value]) => (
+          <button
+            key={key}
+            onClick={() => setSubject(key as SubjectKey)}
+            className={`rounded px-4 py-2 text-xs font-medium transition ${
+              subject === key
+                ? "text-amber-400 hover:text-amber-600"
+                : "text-white hover:text-amber-600"
+            }`}
+          >
+            {value.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Mobile drawer */}
+      {mobileMenuOpen && (
+        <div
+          className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm lg:hidden"
+          onClick={() => setMobileMenuOpen(false)}
+        >
+          <div
+            className="absolute left-0 top-0 h-full w-full bg-surface-light p-4 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-base font-semibold text-white">
+                Choose subject
+              </h2>
+              <button
+                onClick={() => setMobileMenuOpen(false)}
+                className="text-slate-300 hover:text-white"
+              >
+                <span className="material-symbols-outlined">close</span>
+              </button>
+            </div>
+
+            <div className="flex flex-col gap-2 overflow-y-auto">
+              {subjects.map(([key, value]) => (
+                <button
+                  key={key}
+                  onClick={() => handleSelect(key as SubjectKey)}
+                  className={`rounded-xl px-4 py-3 text-left text-sm font-medium transition ${
+                    subject === key
+                      ? "bg-secondary-500 text-black"
+                      : "bg-surface text-white hover:bg-black/40"
+                  }`}
+                >
+                  {value.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -34,7 +34,7 @@ export function Toolbar({
           </div>
 
           <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-between xl:justify-end">
-            <div className="flex  flex-wrap items-center gap-2 rounded-xl bg-black/20 px-4 h-8 shadow-sm shadow-primary-500/10 inset-shadow-sm inset-shadow-black/20">
+            <div className="flex lg:flex-row flex-wrap items-center gap-2 rounded-xl bg-black/20 px-4 py-4 lg:h-8 lg:py-0 shadow-sm shadow-primary-500/10 inset-shadow-sm inset-shadow-black/20">
               <label className="flex items-center gap-2 text-xs text-slate-300">
                 <input
                   type="checkbox"
@@ -56,7 +56,7 @@ export function Toolbar({
               </label>
             </div>
 
-            <div className="flex flex-row gap-2">
+            <div className="flex flex-col lg:flex-row gap-2">
               <Button
                 buttonLabel="Reset Study"
                 buttonStyle="tertiary"
@@ -81,8 +81,8 @@ export function Toolbar({
           </div>
         </div>
       </div>
-      <div className="flex justify-between items-center bg-black/70 rounded-xl px-4 py-3 border border-black/90 text-xs text-white/50">
-        <div className="flex">
+      <div className="flex flex-col lg:flex-row gap-4 lg:gap-0 justify-between items-center bg-black/70 rounded-xl px-4 py-3 border border-black/90 text-xs text-white/50">
+        <div className="flex flex-col lg:flex-row gap-4 lg:gap-0">
           <p
             className={`text-xs text-left transition ${reviewedCount > 0 ? "opacity-100" : "opacity-50"}`}
           >
@@ -94,7 +94,7 @@ export function Toolbar({
               : `${reviewedCount} topic completed`}
           </p>
           <p
-            className={`text-xs pl-4 text-left transition ${flaggedCount > 0 ? "opacity-100" : "opacity-50"}`}
+            className={`text-xs lg:pl-4 text-left transition ${flaggedCount > 0 ? "opacity-100" : "opacity-50"}`}
           >
             <span className="material-symbols-outlined align-middle mr-1 text-primary-500">
               flag
@@ -104,7 +104,7 @@ export function Toolbar({
               : `${flaggedCount} topic flagged for review`}
           </p>
           <p
-            className={`text-xs pl-4 text-left transition ${mockQuestionsCount > 0 ? "opacity-100" : "opacity-50"}`}
+            className={`text-xs lg:pl-4 text-left transition ${mockQuestionsCount > 0 ? "opacity-100" : "opacity-50"}`}
           >
             <span className="material-symbols-outlined align-middle mr-1 text-secondary-500">
               quick_reference
@@ -114,16 +114,17 @@ export function Toolbar({
               : `${mockQuestionsCount} topic added to mock interview`}
           </p>
         </div>
-        <div className="flex items-center">
+        <div className="flex flex-col lg:flex-row gap-2 lg:gap-0 items-center w-full lg:w-auto">
           <Button
             buttonLabel="Mock Interview"
             buttonIcon="groups"
             buttonStyle="primary"
             handleClick={onShowMockQuestions}
+            extraClasses="w-full justify-center lg:w-auto lg:justify-normal"
           />
 
           {subjectScore !== null && (
-            <p className="pl-4 text-xs text-left text-white/80">
+            <p className="lg:pl-4 text-xs text-center lg:text-left text-white/80">
               <span className="material-symbols-outlined align-middle mr-1 text-primary-400">
                 workspace_premium
               </span>

--- a/src/components/TopicItem.tsx
+++ b/src/components/TopicItem.tsx
@@ -26,7 +26,7 @@ function TopicItem({
           : "border-black/50 bg-card hover:bg-card-hover hover:border-black"
       } ${isOpen ? "bg-card-hover" : ""}`}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex items-start lg:items-center gap-3">
         <input
           type="checkbox"
           checked={isChecked}
@@ -41,20 +41,20 @@ function TopicItem({
             if (e.key === "ArrowDown") onArrowDown();
             if (e.key === "ArrowUp") onArrowUp();
           }}
-          className="flex flex-1 items-center justify-between gap-4 text-left group"
+          className="flex flex-1 items-start lg:items-center justify-between lg:gap-4 text-left group"
         >
           <div className="flex items-center gap-3 w-full justify-between">
-            <div>
+            <div className="flex flex-col">
               <span className="font-medium text-slate-100">{item.name}</span>
 
               {item.interview && (
-                <span className="ml-2 rounded bg-primary-500 px-2 py-0.5 text-xxs text-black shadow-lg shadow-white/10">
+                <span className="lg:ml-2 rounded bg-primary-500 px-1 lg:px-2 lg:py-0.5 text-xxs text-black shadow-lg shadow-white/10">
                   Potential interview question
                 </span>
               )}
             </div>
 
-            <div className="flex gap-2 justify-end">
+            <div className="hidden lg:flex gap-2 justify-end">
               {isMockSelected && (
                 <span className="flex items-center bg-secondary-500 border border-black/70 px-2 pl-3 text-xxs text-black/70 rounded shadow-lg shadow-white/10">
                   Mock interview question{" "}
@@ -103,13 +103,13 @@ function TopicItem({
       </div>
 
       {isOpen && (
-        <div className="mt-3 space-y-3 pl-7">
+        <div className="mt-3 space-y-3 lg:pl-7">
           <p className="mb-6 text-xs leading-6 text-slate-300">
             {item.summary}
           </p>
 
           {item.code && (
-            <div className="relative">
+            <div className="relative hidden lg:block">
               <span className="absolute top-0 right-10 text-xxs bg-secondary text-black px-2 uppercase shadow-lg shadow-secondary/30 rounded-b ">
                 {subjectData[subject].fileType}
               </span>
@@ -145,7 +145,7 @@ function TopicItem({
             </div>
           )}
 
-          <div className="flex gap-4 mt-4">
+          <div className="flex flex-col lg:flex-row gap-2 lg:gap-4 mt-4">
             {item.mockQuestions && (
               <button
                 onClick={(e) => {

--- a/src/components/TopicModal.tsx
+++ b/src/components/TopicModal.tsx
@@ -25,6 +25,13 @@ export function TopicModal({
 
     return () => cancelAnimationFrame(id);
   }, []);
+
+  useEffect(() => {
+    if (isVisible) {
+      document.body.style.overflow = "hidden";
+    }
+  }, [isVisible]);
+
   const totalTopics = section.items.length;
 
   const completedTopics = section.items.filter(

--- a/src/components/shared/Button/Button.tsx
+++ b/src/components/shared/Button/Button.tsx
@@ -4,9 +4,9 @@ export function Button({
   buttonIcon,
   buttonStyle = "primary",
   handleClick,
+  extraClasses,
 }: ButtonProps) {
-  const baseClasses =
-    "flex items-center rounded-xl px-4 h-8 text-xxs transition shadow-sm";
+  const baseClasses = `flex items-center rounded-xl px-4 h-8 text-xxs transition shadow-sm ${extraClasses}`;
   const styleMap = {
     primary:
       "bg-primary-500 text-black hover:bg-primary-600 shadow-primary-400",

--- a/src/components/shared/Button/types.ts
+++ b/src/components/shared/Button/types.ts
@@ -3,4 +3,5 @@ export type ButtonProps = {
   buttonIcon?: string;
   buttonStyle?: "primary" | "secondary" | "tertiary";
   handleClick: () => void;
+  extraClasses?: string;
 };


### PR DESCRIPTION
Improves the mobile experience across the app with a new mobile navigation drawer and responsive layout fixes.

## Changes

- **SubjectNav component** – new component with a mobile drawer and desktop inline nav, replacing the previous inline subject buttons in `App.tsx`
- **Responsive layouts** – updated `TopicItem`, `Toolbar`, `MockInterviewNoQuestions`, and `MockInterviewQuestions` with responsive Tailwind classes (`lg:`, `xl:`)
- **Scroll locking** – `TopicModal` and `SubjectNav` now lock `document.body` overflow when open to prevent background scroll
- **Button `extraClasses` prop** – added optional `extraClasses` prop to the shared `Button` component for one-off styling overrides
- **Misc** – removed stray `console.log` calls in `App.tsx`

Co-Authored-By: Oz <oz-agent@warp.dev>