### PR TITLE
Fixed bug that prevented interview from resetting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ export default function App() {
   const [showFlaggedOnly, setShowFlaggedOnly] = useState(false);
   const [showMockQuestions, setShowMockQuestions] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [mockInterviewResetKey, setMockInterviewResetKey] = useState(0);
 
   const sections = subjectData[subject].sections;
   const subjects = Object.entries(subjectData);
@@ -124,8 +125,14 @@ export default function App() {
           flaggedCount={flaggedCount}
           mockQuestionsCount={mockQuestionsCount}
           onResetProgress={() => resetStudyProgress(subject)}
-          onResetInterviewProgress={() => resetInterviewProgress(subject)}
-          onResetAllProgress={() => resetAllProgress(subject)}
+          onResetInterviewProgress={() => {
+            resetInterviewProgress(subject);
+            setMockInterviewResetKey((prev) => prev + 1);
+          }}
+          onResetAllProgress={() => {
+            resetAllProgress(subject);
+            setMockInterviewResetKey((prev) => prev + 1);
+          }}
           showInterviewOnly={showInterviewOnly}
           onShowInterviewOnlyChange={setShowInterviewOnly}
           showFlaggedOnly={showFlaggedOnly}
@@ -162,6 +169,7 @@ export default function App() {
       </div>
 
       <MockInterview
+        key={`${subject}-${mockInterviewResetKey}`}
         subject={subject}
         showMockQuestions={showMockQuestions}
         setShowMockQuestions={setShowMockQuestions}

--- a/src/components/MockInterview/MockInterview.tsx
+++ b/src/components/MockInterview/MockInterview.tsx
@@ -49,7 +49,7 @@ export function MockInterview({
     Object.entries(sectionTotals).forEach(([sectionTitle, totals]) => {
       const sectionPercentage =
         totals.max > 0 ? Math.round((totals.earned / totals.max) * 100) : 0;
-      console.log("saving", {subject, sectionTitle, sectionPercentage});
+
       saveInterviewScore(subject, sectionTitle, sectionPercentage);
     });
 

--- a/src/components/MockInterview/MockInterviewQuestions.tsx
+++ b/src/components/MockInterview/MockInterviewQuestions.tsx
@@ -25,7 +25,7 @@ export function MockInterviewQuestions({
       >
         <div>
           <div className="mb-4 flex flex-col gap-4 lg:gap-0 items-center lg:items-start">
-            <div className="flex flex-col justify-between items-center">
+            <div className="flex flex-col lg:flex-row lg:w-full justify-between items-center">
               <h2 className="text-xl font-semibold">
                 {subjectData[subject].label} Mock Interview
               </h2>

--- a/src/hooks/useLearningProgress.ts
+++ b/src/hooks/useLearningProgress.ts
@@ -132,11 +132,16 @@ export function useLearningProgress() {
   };
 
   const resetInterviewProgress = (subject: SubjectKey) => {
-    setInterviewScores((prev) =>
-      Object.fromEntries(
+    setInterviewScores((prev) => {
+      console.log("before reset", prev);
+
+      const next = Object.fromEntries(
         Object.entries(prev).filter(([key]) => !key.startsWith(`${subject}::`)),
-      ),
-    );
+      );
+
+      console.log("after reset", next);
+      return next;
+    });
   };
 
   const removeSubjectEntries = <T extends Record<string, unknown>>(


### PR DESCRIPTION
Mock interviews were not resetting properly as state was persisting.

Have updated click handlers to ensure they are updated correctly.